### PR TITLE
updated image tag to 1.2.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
   #crowdsec : it will be fed nginx's logs
   #and later we're going to plug a firewall bouncer to it
   crowdsec:
-    image: crowdsecurity/crowdsec:v1.0.8
+    image: crowdsecurity/crowdsec:v1.2.0
     restart: always
     environment:
       #this is the list of collections we want to install


### PR DESCRIPTION
this repository is linked by a blog post published on September 1st, but is broken because release 1.0.8 gets 404 errors from the hub