### PR TITLE
NPM - Add notice and fix for NPM not banning source IP

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -22,6 +22,9 @@ echo "CROWDSEC_BOUNCER_APIKEY=<key shown from above output>" >> .env
 docker compose down
 ```
 
+By default, NPM does not report the original client's IP, but rather the CDN or other proxy IP in between the client and your server. If you run Crowdsec, it will ban this middle-man IP rather than the source IP. 
+In order to ban the source IP, use the file in `/data/nginx/custom/server_proxy.conf`. [View here for more information](https://nginxproxymanager.com/advanced-config/#custom-nginx-configurations). This will set `real_ip_header X-Forwarded-For` to all proxy hosts globally. 
+
 Then you can start the containers as normal 
 
 ```bash

--- a/npm/data/nginx/custom/server_proxy.conf
+++ b/npm/data/nginx/custom/server_proxy.conf
@@ -1,0 +1,1 @@
+real_ip_header X-Forwarded-For;


### PR DESCRIPTION
NPM by default will report the CDN (or proxy, etc) in between the source IP and the host's server IP, rather than the source IP itself. For me, this results in a ton of Cloudflare CDNs being banned rather than the offending IP.

This PR fixes this by adding a simple global setting for all proxy hosts, switching `real_ip_header` to `X-Forwarded-For`. README is also edited to reflect this.