### PR TITLE
fix syntax for networks list and keep it local

### DIFF
--- a/container-labels/docker-compose-crowdsec.yml
+++ b/container-labels/docker-compose-crowdsec.yml
@@ -3,7 +3,7 @@ services:
     image: crowdsecurity/crowdsec:v1.6.2 ## container labels were introduced in 1.6.2
     restart: always
     networks:
-      crowdsec:
+      - crowdsec
     environment:
       DOCKER_HOST: tcp://socket-proxy:2375
       COLLECTIONS: "crowdsecurity/nginx"
@@ -18,7 +18,7 @@ services:
 
   socket-proxy:
     networks:
-      crowdsec:
+      - crowdsec
     restart: always
     image: lscr.io/linuxserver/socket-proxy:latest
     container_name: socket-proxy
@@ -54,4 +54,3 @@ volumes:
 
 networks:
   crowdsec:
-    driver: bridge


### PR DESCRIPTION
There is a syntax error for the networks in the services and afaik bridge mode makes the network accessible. socket-proxy is best kept to an internal network.