### PR TITLE
Update docker-compose.yml to fix problem with volumes, configuration directory, and aquis.yaml file

### DIFF
--- a/caddy/docker-compose.yml
+++ b/caddy/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - BOUNCER_KEY_CADDY=${CROWDSEC_API_KEY}
     volumes:
       - crowdsec-db:/var/lib/crowdsec/data/
-      - ./crowdsec/acquis.yaml:/etc/crowdsec/acquis.yaml
+      - ./crowdsec:/etc/crowdsec
       - caddy-logs:/var/log/caddy:ro
     networks:
       crowdsec:


### PR DESCRIPTION
Volumes in docker should be directory rather than a specific directory/filename (as it is in the current version: /etc/crowdsec/aquis.yaml rather than simply /etc/crowdsec).

After the change, the compose.yml file seems to work and all config files are in place in ./crowdsec (local) and /etc/crowdsec (within container)